### PR TITLE
Make pretty-print output in example easier to read

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,13 @@
 //!     f.pretty(|f| uDebug::fmt(&pair, f))
 //! }.unwrap();
 //!
-//! assert_eq!(s, "Pair {\n    x: 1,\n    y: 2,\n}");
+//! let pretty = "\
+//! Pair {
+//!     x: 1,
+//!     y: 2,
+//! }";
+//!
+//! assert_eq!(s, pretty);
 //! ```
 //!
 //! - on stable: implementing `uWrite`


### PR DESCRIPTION
I think that using escaped newline characters here causes the reader to take a bit more time in understanding how the expected output is supposed to look. Also, having a multi-line string literal that reflects how the output would appear when actually printed makes the example... prettier 😄.