### PR TITLE
Add support for 16-bit pointer width

### DIFF
--- a/src/impls/ixx.rs
+++ b/src/impls/ixx.rs
@@ -107,7 +107,7 @@ impl uDisplay for i32 {
 }
 
 impl uDebug for i64 {
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
     where
         W: uWrite,
@@ -162,6 +162,15 @@ impl uDisplay for i128 {
 }
 
 impl uDebug for isize {
+    #[cfg(target_pointer_width = "16")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite,
+    {
+        <i16 as uDebug>::fmt(&(*self as i16), f)
+    }
+
     #[cfg(target_pointer_width = "32")]
     #[inline(always)]
     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
@@ -182,6 +191,15 @@ impl uDebug for isize {
 }
 
 impl uDisplay for isize {
+    #[cfg(target_pointer_width = "16")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite,
+    {
+        <i16 as uDisplay>::fmt(&(*self as i16), f)
+    }
+
     #[cfg(target_pointer_width = "32")]
     #[inline(always)]
     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>

--- a/src/impls/ptr.rs
+++ b/src/impls/ptr.rs
@@ -43,6 +43,14 @@ fn hex(mut n: usize, buf: &mut [u8]) -> usize {
 }
 
 impl<T> uDebug for *const T {
+    #[cfg(target_pointer_width = "16")]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite,
+    {
+        hex!(self, f, 6)
+    }
+
     #[cfg(target_pointer_width = "32")]
     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
     where

--- a/src/impls/uxx.rs
+++ b/src/impls/uxx.rs
@@ -91,7 +91,7 @@ impl uDisplay for u32 {
 }
 
 impl uDebug for u64 {
-    #[cfg(target_pointer_width = "32")]
+    #[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
     where
         W: uWrite,
@@ -146,6 +146,15 @@ impl uDisplay for u128 {
 }
 
 impl uDebug for usize {
+    #[cfg(target_pointer_width = "16")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite,
+    {
+        <u16 as uDebug>::fmt(&(*self as u16), f)
+    }
+
     #[cfg(target_pointer_width = "32")]
     #[inline(always)]
     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
@@ -166,6 +175,15 @@ impl uDebug for usize {
 }
 
 impl uDisplay for usize {
+    #[cfg(target_pointer_width = "16")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite,
+    {
+        <u16 as uDisplay>::fmt(&(*self as u16), f)
+    }
+
     #[cfg(target_pointer_width = "32")]
     #[inline(always)]
     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>


### PR DESCRIPTION
For using this crate on AVR, the pointer-width dependent code has to have implementations for 16 bit as well.