### PR TITLE
Replace uWrite impl for String by generic impl for all Write impls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,18 +162,6 @@
 //!
 //! struct W;
 //!
-//! impl uWrite for W {
-//!     type Error = Infallible;
-//!
-//!     fn write_str(&mut self, s: &str) -> Result<(), Infallible> {
-//!         s.as_bytes()
-//!             .iter()
-//!             .for_each(|b| unsafe { drop(ptr::read_volatile(b)) });
-//!
-//!         Ok(())
-//!     }
-//! }
-//!
 //! impl fmt::Write for W {
 //!     fn write_str(&mut self, s: &str) -> fmt::Result {
 //!         s.as_bytes()

--- a/write/src/lib.rs
+++ b/write/src/lib.rs
@@ -6,8 +6,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(warnings)]
 
-#[cfg(feature = "std")]
-use core::convert::Infallible;
+use core::fmt::Error;
 
 #[allow(deprecated)]
 unsafe fn uninitialized<T>() -> T {
@@ -37,12 +36,11 @@ pub trait uWrite {
     }
 }
 
-#[cfg(feature = "std")]
-impl uWrite for String {
-    type Error = Infallible;
+impl<T: core::fmt::Write> uWrite for T
+{
+    type Error = Error;
 
-    fn write_str(&mut self, s: &str) -> Result<(), Infallible> {
-        self.push_str(s);
-        Ok(())
+    fn write_str(&mut self, s: &str) -> Result<(), Error> {
+        self.write_str(s)
     }
 }


### PR DESCRIPTION
Alternative version using core::fmt::Error as return type instead of
Infallible.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>