### PR TITLE
Fix derive uDebug in case a non-core Result is in scope

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -79,7 +79,7 @@ pub fn debug(input: TokenStream) -> TokenStream {
 
             quote!(
                 impl #impl_generics ufmt::uDebug for #ident #ty_generics #where_clause {
-                    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+                    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> core::result::Result<(), W::Error>
                     where
                         W: ufmt::uWrite + ?Sized,
                     {
@@ -140,7 +140,7 @@ pub fn debug(input: TokenStream) -> TokenStream {
 
             quote!(
                 impl #impl_generics ufmt::uDebug for #ident #ty_generics #where_clause {
-                    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+                    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> core::result::Result<(), W::Error>
                         where
                         W: ufmt::uWrite + ?Sized,
                     {


### PR DESCRIPTION
When there is a custom Result in scope (e.g., deriving uDebug on dependent library Error/Result pair), a hard-to-guess `unexpected type argument` error occurs.