### PR TITLE
Remove dependency on `proc-macro-hack`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,18 @@ repository = "https://github.com/japaric/ufmt"
 version = "0.1.0"
 
 [dependencies]
-proc-macro-hack = "0.5.11"
+proc-macro-hack = { version = "0.5.11", optional = true }
 ufmt-macros = { path = "macros", version = "0.1.0" }
 ufmt-write = { path = "write", version = "0.1.0" }
 
 # NOTE do NOT add an `alloc` feature before the alloc crate can be used in
 # no-std BINARIES
 [features]
+default = ["legacy"]
+
 # NOTE do NOT turn `std` into a default feature; this is a no-std first crate
 std = ["ufmt-write/std"]
+legacy = ["proc-macro-hack", "ufmt-macros/proc-macro-hack"]
 
 [[test]]
 name = "vs-std-write"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ ufmt-write = { path = "write", version = "0.1.0" }
 # NOTE do NOT add an `alloc` feature before the alloc crate can be used in
 # no-std BINARIES
 [features]
-default = ["legacy"]
-
 # NOTE do NOT turn `std` into a default feature; this is a no-std first crate
 std = ["ufmt-write/std"]
 legacy = ["proc-macro-hack", "ufmt-macros/proc-macro-hack"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.1"
 proc-macro = true
 
 [dependencies]
-proc-macro-hack = "0.5.11"
+proc-macro-hack = { version = "0.5.11", optional = true }
 proc-macro2 = "1"
 quote = "1"
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -9,7 +9,6 @@ use proc_macro::TokenStream;
 use std::borrow::Cow;
 
 use proc_macro2::{Literal, Span};
-use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 use syn::{
     parse::{self, Parse, ParseStream},
@@ -162,12 +161,14 @@ pub fn debug(input: TokenStream) -> TokenStream {
     ts.into()
 }
 
-#[proc_macro_hack]
+#[cfg_attr(feature = "proc-macro-hack", proc_macro_hack::proc_macro_hack)]
+#[cfg_attr(not(feature = "proc-macro-hack"), proc_macro)]
 pub fn uwrite(input: TokenStream) -> TokenStream {
     write(input, false)
 }
 
-#[proc_macro_hack]
+#[cfg_attr(feature = "proc-macro-hack", proc_macro_hack::proc_macro_hack)]
+#[cfg_attr(not(feature = "proc-macro-hack"), proc_macro)]
 pub fn uwriteln(input: TokenStream) -> TokenStream {
     write(input, true)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,6 @@ extern crate self as ufmt;
 
 use core::str;
 
-use proc_macro_hack::proc_macro_hack;
 pub use ufmt_write::uWrite;
 
 /// Write formatted data into a buffer
@@ -224,13 +223,13 @@ pub use ufmt_write::uWrite;
 /// Named parameters and "specified" positional parameters (`{0}`) are not supported.
 ///
 /// `{{` and `}}` can be used to escape braces.
-#[proc_macro_hack]
+#[cfg_attr(feature = "proc-macro-hack", proc_macro_hack::proc_macro_hack)]
 pub use ufmt_macros::uwrite;
 
 /// Write formatted data into a buffer, with a newline appended
 ///
 /// See [`uwrite!`](macro.uwrite.html) for more details
-#[proc_macro_hack]
+#[cfg_attr(feature = "proc-macro-hack", proc_macro_hack::proc_macro_hack)]
 pub use ufmt_macros::uwriteln;
 
 pub use crate::helpers::{DebugList, DebugMap, DebugStruct, DebugTuple};


### PR DESCRIPTION
Has not been required since Rust 1.45. For legacy support, ufmt will
still use `proc-macro-hack` when the `legacy` feature is enabled (by
default). Users on later Rust versions can disable it by disabling
default features.