### PR TITLE
ufmt v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.1.2] - 2022-08-10
+
+## Added
+
+- added support for hexadecimal formatting of integers using the `{:x}` format string
+
 ## [v0.1.1] - 2022-08-09
 
 ### Fixed
@@ -18,5 +24,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/japaric/ufmt/compare/ufmt-v0.1.1...HEAD
+[Unreleased]: https://github.com/japaric/ufmt/compare/ufmt-v0.1.2...HEAD
+[v0.1.2]: https://github.com/japaric/ufmt/compare/ufmt-v0.1.1...ufmt-v0.1.2
 [v0.1.1]: https://github.com/japaric/ufmt/compare/ufmt-v0.1.0...ufmt-v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ license = "MIT OR Apache-2.0"
 name = "ufmt"
 readme = "README.md"
 repository = "https://github.com/japaric/ufmt"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 proc-macro-hack = "0.5.11"
-ufmt-macros = { path = "macros", version = "0.1.0" }
+ufmt-macros = { path = "macros", version = "0.2.0" }
 ufmt-write = { path = "write", version = "0.1.0" }
 
 # NOTE do NOT add an `alloc` feature before the alloc crate can be used in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 //! - [`core::fmt::Formatter::debug_struct`][debug_struct]-like API
 //! - [`#[derive(uDebug)]`][derive]
 //! - Pretty formatting (`{:#?}`) for `uDebug`
+//! - Hexadecimal formatting (`{:x}`) of integer primitives (e.g. `i32`) -- currently cannot be extended to other types
 //!
 //! [`Debug`]: trait.uDebug.html
 //! [`Display`]: trait.uDisplay.html
@@ -50,6 +51,19 @@
 //! let pair = Pair { x: 1, y: 2 };
 //! uwrite!(s, "{:?}", pair).unwrap();
 //! assert_eq!(s, "Pair { x: 1, y: 2 }");
+//! ```
+//!
+//! - Hexadecimal formatting
+//!
+//! Lowercase (`{:x}`), uppercase (`{:X}`), `0x`-prefix (`{:#x}`) and padding (`{:02x}`) are
+//! supported on primitive integer types. 
+//!
+//! ```
+//! use ufmt::uwrite;
+//!
+//! let mut s = String::new();
+//! uwrite!(s, "{:#06x}", 0x42);
+//! assert_eq!(s, "0x0042");
 //! ```
 //!
 //! - implementing `uWrite`
@@ -268,7 +282,10 @@ pub trait uDisplay {
         W: uWrite + ?Sized;
 }
 
-/// options for formatting hexadecimal numbers
+/// HEADS UP this is currently an implementation detail and not subject to semver guarantees.
+/// do NOT use this outside the `ufmt` crate
+// options for formatting hexadecimal numbers
+#[doc(hidden)]
 pub struct HexOptions {
     /// when we need to use digits a-f, should they be upper case instead?
     pub upper_case: bool,
@@ -323,7 +340,10 @@ impl HexOptions {
     }
 }
 
-/// just like std::fmt::LowerHex
+/// HEADS UP this is currently an implementation detail and not subject to semver guarantees.
+/// do NOT use this outside the `ufmt` crate
+// just like std::fmt::LowerHex
+#[doc(hidden)]
 #[allow(non_camel_case_types)]
 pub trait uDisplayHex {
     /// Formats the value using the given formatter


### PR DESCRIPTION
as a PR because of the added doc test. also make the hexadecimal formatting internals private for now