### PR TITLE
rm proc-macro-hack; use regular proc-macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/japaric/ufmt"
 version = "0.2.0"
 
 [dependencies]
-proc-macro-hack = "0.5.11"
 ufmt-macros = { path = "macros", version = "0.3.0" }
 ufmt-write = { path = "write", version = "0.1.0" }
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.3.0"
 proc-macro = true
 
 [dependencies]
-proc-macro-hack = "0.5.11"
 proc-macro2 = "1"
 quote = "1"
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,7 +10,6 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 
 use proc_macro2::{Literal, Span};
-use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 use syn::{
     parse::{self, Parse, ParseStream},
@@ -174,12 +173,12 @@ pub fn debug(input: TokenStream) -> TokenStream {
     ts.into()
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn uwrite(input: TokenStream) -> TokenStream {
     write(input, false)
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn uwriteln(input: TokenStream) -> TokenStream {
     write(input, true)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,13 +90,6 @@
 //!
 //! - writing a `macro_rules!` macro that uses `uwrite!` (or `uwriteln!`).
 //!
-//! Both `ufmt` macros are implemented using [`proc-macro-hack`]; care is needed to avoid running
-//! into the compiler bug [#43081](https://github.com/rust-lang/rust/issues/43081). See also
-//! [dtolnay/proc-macro-hack#46][pmh-46].
-//!
-//! [`proc-macro-hack`]: https://github.com/dtolnay/proc-macro-hack
-//! [pmh-46]: https://github.com/dtolnay/proc-macro-hack/issues/46
-//!
 //! ```
 //! // like `std::format!` it returns a `std::String` but uses `uwrite!` instead of `write!`
 //! macro_rules! uformat {
@@ -220,7 +213,6 @@ extern crate self as ufmt;
 
 use core::str;
 
-use proc_macro_hack::proc_macro_hack;
 pub use ufmt_write::uWrite;
 
 /// Write formatted data into a buffer
@@ -241,13 +233,11 @@ pub use ufmt_write::uWrite;
 /// Named parameters and "specified" positional parameters (`{0}`) are not supported.
 ///
 /// `{{` and `}}` can be used to escape braces.
-#[proc_macro_hack]
 pub use ufmt_macros::uwrite;
 
 /// Write formatted data into a buffer, with a newline appended
 ///
 /// See [`uwrite!`](macro.uwrite.html) for more details
-#[proc_macro_hack]
 pub use ufmt_macros::uwriteln;
 
 pub use crate::helpers::{DebugList, DebugMap, DebugStruct, DebugTuple};


### PR DESCRIPTION
alternative to #34 that does not add a Cargo feature
closes #34