### PR TITLE
fixed uDebug derive for types with a W generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Fixed
+
+- fixed `uDebug` derive for types with a `W` generic
+
 ## [v0.2.0] - 2022-08-10
 
 ## Changed

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -79,9 +79,9 @@ pub fn debug(input: TokenStream) -> TokenStream {
 
             quote!(
                 impl #impl_generics ufmt::uDebug for #ident #ty_generics #where_clause {
-                    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> core::result::Result<(), W::Error>
+                    fn fmt<WriterUfmt>(&self, f: &mut ufmt::Formatter<'_, WriterUfmt>) -> core::result::Result<(), WriterUfmt::Error>
                     where
-                        W: ufmt::uWrite + ?Sized,
+                        WriterUfmt: ufmt::uWrite + ?Sized,
                     {
                         #body
                     }


### PR DESCRIPTION
Adding the `uDebug` derive to existing code that has a `W` generic will fail to compile.

```rust
#[derive(ufmt::derive::uDebug)]
struct MyStruct<W> {
    w: W,
}
```

```text
error[E0403]: the name `W` is already used for a generic parameter in this item's generic parameters

1 | #[derive(ufmt::derive::uDebug)]
  |          ^^^^^^^^^^^^^^^^^^^^ already used
2 | struct MyStruct<W> {
  |                 - first use of `W`
```

I do not know if there is a way to eliminate this problem.  Changing the generic from a 1-letter name to `WriterUfmt` should work in almost all cases.
