### PR TITLE
Add license texts to all crates

### DIFF
--- a/macros/LICENSE-APACHE
+++ b/macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/macros/LICENSE-MIT
+++ b/macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/nopanic/LICENSE-APACHE
+++ b/nopanic/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/nopanic/LICENSE-MIT
+++ b/nopanic/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/utils/LICENSE-APACHE
+++ b/utils/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/utils/LICENSE-MIT
+++ b/utils/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/write/LICENSE-APACHE
+++ b/write/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/write/LICENSE-MIT
+++ b/write/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
This is necessary for distribution packaging, esp. for MIT-licensed files

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>