### PR TITLE
add binary formatting (proof-of-concept)

### DIFF
--- a/macros/CHANGELOG.md
+++ b/macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- added support for `{:b}`-style formatting arguments. must be used with `ufmt` 0.1.2+
+
 ## [v0.3.0] - 2022-08-10
 
 ## Changed

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,4 +1,5 @@
 mod array;
+mod bin;
 mod core;
 mod hex;
 mod ixx;

--- a/src/impls/bin.rs
+++ b/src/impls/bin.rs
@@ -1,0 +1,70 @@
+use crate::{uDisplayBin, uWrite, BinOptions, Formatter};
+
+macro_rules! bin_format {
+    ($buf:expr, $val:expr, $options:expr) => {{
+        let mut cursor = $buf.len();
+        let mut val = $val;
+        if val <= 0 {
+            cursor -= 1;
+            $buf[cursor] = b'0';
+        } else {
+            while val != 0 && cursor > 0 {
+                let rem = val & 0b1;
+                cursor -= 1;
+                $buf[cursor] = bin_digit(rem as u8, $options.upper_case);
+                val >>= 1;
+            }
+        }
+        unsafe { core::str::from_utf8_unchecked(&$buf[cursor..]) }
+    }};
+}
+
+macro_rules! bin_pattern {
+    ($itype: ty, $utype:ty) => {
+        impl uDisplayBin for $itype {
+            fn fmt_bin<W>(
+                &self,
+                fmt: &mut Formatter<'_, W>,
+                options: BinOptions,
+            ) -> Result<(), W::Error>
+            where
+                W: uWrite + ?Sized,
+            {
+                let positive = if false && // the standard rust library doesn't format negative numbers with a minus sign
+                *self < 0 {
+                    fmt.write_char('-')?;
+                    ((!*self) as $utype).wrapping_add(1)
+                } else {
+                    *self as $utype
+                };
+                <$utype as uDisplayBin>::fmt_bin(&positive, fmt, options)
+            }
+        }
+
+        impl uDisplayBin for $utype {
+            fn fmt_bin<W>(
+                &self,
+                fmt: &mut Formatter<'_, W>,
+                options: BinOptions,
+            ) -> Result<(), W::Error>
+            where
+                W: uWrite + ?Sized,
+            {
+                let mut buffer = [b'0'; 2 * core::mem::size_of::<$utype>()];
+                let bin_string = bin_format!(buffer, *self, options);
+                options.with_stuff(fmt, bin_string)
+            }
+        }
+    };
+}
+
+bin_pattern! {i8, u8}
+bin_pattern! {i16, u16}
+bin_pattern! {i32, u32}
+bin_pattern! {i64, u64}
+bin_pattern! {i128, u128}
+bin_pattern! {isize, usize}
+
+fn bin_digit(val: u8, _upper_case: bool) -> u8 {
+    b'0' + val
+}


### PR DESCRIPTION
Hello there!

I wanted to suggest adding binary/octal (and potentially exponential for `f32`/`f64`) formatting support for numbers. As a proof-of-concept, I have adjusted the structures needed for hex-formatting to showcase that the same workflow would work with the other mentioned types. I would even expect that we could create a unified interface & macros for the definitions for the impl blocks.

Some thoughts:
- It seems that the only thing that changes is the mask (`0xf` vs. `0b1`) and the bitshift operation, as well as some constant (e.g. the prefix would be `0b`).
- More precisely, if you have a bit shift by `x`, then your mask is `2.pow(x) - 1` – maybe that could be used in the macro as well.
- The `HexOptions` struct could be renamed and reused for all those number format options, I believe.

What's your opinion on this? Are there any plans to include such functionality anyways?