### PR TITLE
feat: implement `uDebug` for `PhantomData`

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -2,6 +2,7 @@ mod array;
 mod core;
 mod hex;
 mod ixx;
+mod marker;
 mod nz;
 mod ptr;
 #[cfg(feature = "std")]

--- a/src/impls/marker.rs
+++ b/src/impls/marker.rs
@@ -1,0 +1,13 @@
+use crate::{uDebug, uWrite, Formatter};
+use core::{any::type_name, marker::PhantomData};
+
+impl<T> uDebug for PhantomData<T> {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        f.write_str("PhantomData<")?;
+        f.write_str(type_name::<T>())?;
+        f.write_str("}")
+    }
+}


### PR DESCRIPTION
# Description

This adds an `uDebug` implementation to `PhantomData` based on that in `core::fmt`.