### PR TITLE
Add "inline" feature for do_as_formatter()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ ufmt-write = { path = "write", version = "0.1.0" }
 # NOTE do NOT turn `std` into a default feature; this is a no-std first crate
 std = ["ufmt-write/std"]
 
+# When enabled, do_as_formatter() will be inlined. This can reduce code size
+# for some applications.
+inline = []
+
 [[test]]
 name = "vs-std-write"
 required-features = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,6 +410,7 @@ where
 {
     type Writer = W;
 
+    #[cfg_attr(feature = "inline", inline(always))]
     fn do_as_formatter(
         &mut self,
         f: impl FnOnce(&mut Formatter<'_, W>) -> Result<(), W::Error>,
@@ -424,6 +425,7 @@ where
 {
     type Writer = W;
 
+    #[cfg_attr(feature = "inline", inline(always))]
     fn do_as_formatter(
         &mut self,
         f: impl FnOnce(&mut Formatter<'_, W>) -> Result<(), W::Error>,


### PR DESCRIPTION
For some applications, using this feature can significantly reduce the size of the firmware image.