### PR TITLE
Get rid of UB with `uninitialized`

### DIFF
--- a/write/src/lib.rs
+++ b/write/src/lib.rs
@@ -32,7 +32,7 @@ pub trait uWrite {
     /// entire byte sequence was successfully written, and this method will not return until all
     /// data has been written or an error occurs.
     fn write_char(&mut self, c: char) -> Result<(), Self::Error> {
-        let mut buf: [u8; 4] = unsafe { uninitialized() };
+        let mut buf = [0; 4];
         self.write_str(c.encode_utf8(&mut buf))
     }
 }


### PR DESCRIPTION
Remove `uninitialized`, which always produces UB when used with integers. We replace it with all zero bits, and trust that the compiler will trivially remove the unnecessary 0-initialization, since `encode_utf8` is write-only.